### PR TITLE
Postgis Adapter Support.

### DIFF
--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -21,7 +21,7 @@ module WithAdvisoryLock
 
       def with_advisory_lock(lock_name, timeout_seconds=nil, &block)
         impl_class = case (connection.adapter_name.downcase)
-          when "postgresql", "empostgresql"
+          when "postgresql", "empostgresql", "postgis"
             WithAdvisoryLock::PostgreSQL
           when "mysql", "mysql2"
             WithAdvisoryLock::MySQL

--- a/lib/with_advisory_lock/version.rb
+++ b/lib/with_advisory_lock/version.rb
@@ -1,3 +1,3 @@
 module WithAdvisoryLock
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
"The activerecord-postgis-adapter is a plugin that provides access to features of the PostGIS geospatial database from ActiveRecord. Technically, it extends the standard postgresql adapter to provide support for the spatial data types and features added by the PostGIS extension."
https://github.com/dazuma/activerecord-postgis-adapter

The gem support now Postgis.
