### PR TITLE
Fix deprecation warnings from minitest

### DIFF
--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -11,7 +11,7 @@ describe 'class methods' do
     it 'returns the name of the last lock acquired' do
       Tag.with_advisory_lock(lock_name) do
         # The lock name may have a prefix if WITH_ADVISORY_LOCK_PREFIX env is set
-        Tag.current_advisory_lock.must_match /#{lock_name}/
+        Tag.current_advisory_lock.must_match(/#{lock_name}/)
       end
     end
   end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -7,14 +7,14 @@ describe 'options parsing' do
 
   specify 'defaults (empty hash)' do
     impl = parse_options({})
-    impl.timeout_seconds.must_equal nil
+    impl.timeout_seconds.must_be_nil
     impl.shared.must_equal false
     impl.transaction.must_equal false
   end
 
   specify 'nil sets timeout to nil' do
     impl = parse_options(nil)
-    impl.timeout_seconds.must_equal nil
+    impl.timeout_seconds.must_be_nil
     impl.shared.must_equal false
     impl.transaction.must_equal false
   end
@@ -41,14 +41,14 @@ describe 'options parsing' do
 
   specify 'hash with shared option sets shared to true' do
     impl = parse_options(shared: true)
-    impl.timeout_seconds.must_equal nil
+    impl.timeout_seconds.must_be_nil
     impl.shared.must_equal true
     impl.transaction.must_equal false
   end
 
   specify 'hash with transaction option set transaction to true' do
     impl = parse_options(transaction: true)
-    impl.timeout_seconds.must_equal nil
+    impl.timeout_seconds.must_be_nil
     impl.shared.must_equal false
     impl.transaction.must_equal true
   end

--- a/test/shared_test.rb
+++ b/test/shared_test.rb
@@ -57,7 +57,7 @@ describe 'shared locks' do
 
     it 'raises an error when attempting to use a shared lock' do
       one = SharedTestWorker.new(true)
-      one.locked?.must_equal nil
+      one.locked?.must_be_nil
       exception = proc {
         one.cleanup!
       }.must_raise ArgumentError


### PR DESCRIPTION
Removes two test output warnings:

1. `test/lock_test.rb:14: warning: ambiguous first argument; put parentheses or a space even after '/' operator`
2. `DEPRECATED: Use assert_nil if expecting nil from test/options_test.rb:44. This will fail in Minitest 6.`