### PR TITLE
Add missing active_support require

### DIFF
--- a/lib/with_advisory_lock.rb
+++ b/lib/with_advisory_lock.rb
@@ -1,4 +1,5 @@
 require 'with_advisory_lock/version'
+require 'active_support'
 
 module WithAdvisoryLock
   extend ActiveSupport::Autoload


### PR DESCRIPTION
`WithAdvisoryLock` has a dependency on the `active_support` gem. This PR adds an explicit require making it easier to leverage the with_advisory_lock gem from other gems (i.e. currently other gems need to do `require 'active_support'` and then `require 'with_advisory_lock'`).