### PR TITLE
Add SQL comment to original lock string for PostgreSQL

### DIFF
--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -10,7 +10,8 @@ module WithAdvisoryLock
     end
 
     def execute_successful?(pg_function)
-      sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name} /* #{lock_name} */"
+      comment = lock_name.gsub(/(\/\*)|(\*\/)/, "--")
+      sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name} /* #{comment} */"
       result = connection.select_value(sql)
       # MRI returns 't', jruby returns true. YAY!
       (result == 't' || result == true)

--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -10,7 +10,7 @@ module WithAdvisoryLock
     end
 
     def execute_successful?(pg_function)
-      sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name}"
+      sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name} /* #{lock_name} */"
       result = connection.select_value(sql)
       # MRI returns 't', jruby returns true. YAY!
       (result == 't' || result == true)

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -14,6 +14,14 @@ describe 'class methods' do
         Tag.current_advisory_lock.must_match /#{lock_name}/
       end
     end
+
+    it 'can obtain a lock with a name that attempts to disrupt a SQL comment' do
+      dangerous_lock_name = 'test */ lock /*'
+      Tag.with_advisory_lock(dangerous_lock_name) do
+        Tag.current_advisory_lock.must_match(/#{Regexp.escape(dangerous_lock_name)}/)
+      end
+
+    end
   end
 
   describe '.advisory_lock_exists?' do


### PR DESCRIPTION
The PostgreSQL implementation requires translating the user-specified lock string into
a pair of 32 bit numbers, which makes the lock and unlock statements opaque in the
SQL logs.

This PR adds a [SQL comment](https://www.postgresql.org/docs/8.0/static/sql-syntax.html#SQL-SYNTAX-COMMENTS) containing the original lock string. The comment will be
removed from the input by the PostgreSQL parser, but it will still show up in logs.

Example rails log *before* this change:

```
2.4.1 :001 > User.with_advisory_lock_result("my_unique_lock_name"){}
   (0.4ms)  SELECT pg_try_advisory_lock(258664313,0) AS t5e3e0f0fd108ec9b914765bb4f539780
   (0.2ms)  SELECT pg_advisory_unlock(258664313,0) AS t1dcddec5851647e514718db76f7b3217
```

Example rails log *after* this change:

```
2.4.1 :008 > User.with_advisory_lock_result("my_unique_lock_name"){}
   (0.3ms)  SELECT pg_try_advisory_lock(258664313,0) AS t983e4b7811f1304eed9685ceb82f93b5 /* my_unique_lock_name */
   (0.2ms)  SELECT pg_advisory_unlock(258664313,0) AS tb920893abfe53ed5418fbbbe8d8ec1d3 /* my_unique_lock_name */
```