### PR TITLE
Add support for nested locks in MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,17 @@ Advisory locks with MySQL and PostgreSQL ignore database transaction boundaries.
 
 You will want to wrap your block within a transaction to ensure consistency.
 
-### MySQL doesn't support nesting
+### MySQL < 5.7.5 doesn't support nesting
 
-With MySQL (at least <= v5.5), if you ask for a _different_ advisory lock within
+With MySQL < 5.7.5, if you ask for a _different_ advisory lock within
 a `with_advisory_lock` block, you will be releasing the parent lock (!!!). A
 `NestedAdvisoryLockError`will be raised in this case. If you ask for the same
 lock name, `with_advisory_lock` won't ask for the lock again, and the block
 given will be yielded to.
+
+This is not an issue in MySQL >= 5.7.5, and no error will be raised for nested
+lock usage. You can override this by passing `force_nested_lock_support: true`
+or `force_nested_lock_support: false` to the `with_advisory_lock` options.
 
 ### Is clustered MySQL supported?
 

--- a/lib/with_advisory_lock.rb
+++ b/lib/with_advisory_lock.rb
@@ -9,6 +9,7 @@ module WithAdvisoryLock
   autoload :DatabaseAdapterSupport
   autoload :Flock
   autoload :MySQL, 'with_advisory_lock/mysql'
+  autoload :MySQLNoNesting, 'with_advisory_lock/mysql_no_nesting'
   autoload :NestedAdvisoryLockError
   autoload :PostgreSQL, 'with_advisory_lock/postgresql'
 end

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -33,7 +33,11 @@ module WithAdvisoryLock
         if adapter.postgresql?
           WithAdvisoryLock::PostgreSQL
         elsif adapter.mysql?
-          WithAdvisoryLock::MySQL
+          if adapter.mysql_nested_lock_support?
+            WithAdvisoryLock::MySQL
+          else
+            WithAdvisoryLock::MySQLNoNesting
+          end
         else
           WithAdvisoryLock::Flock
         end

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -34,7 +34,7 @@ module WithAdvisoryLock
         if adapter.postgresql?
           WithAdvisoryLock::PostgreSQL
         elsif adapter.mysql?
-          nested_lock = if options.respond_to?(:fetch) && [true, false].include?(options.fetch(:force_nested_lock_support))
+          nested_lock = if options.respond_to?(:fetch) && [true, false].include?(options.fetch(:force_nested_lock_support, nil))
                           options.fetch(:force_nested_lock_support)
                         else
                           adapter.mysql_nested_lock_support?

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -12,7 +12,9 @@ module WithAdvisoryLock
       end
 
       def with_advisory_lock_result(lock_name, options = {}, &block)
-        impl = impl_class(options).new(connection, lock_name, options)
+        class_options = options.slice(:force_nested_lock_support)
+        instance_options = options.except(:force_nested_lock_support)
+        impl = impl_class(class_options).new(connection, lock_name, instance_options)
         impl.with_advisory_lock_if_needed(&block)
       end
 

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -29,13 +29,13 @@ module WithAdvisoryLock
 
       private
 
-      def impl_class(options = {})
+      def impl_class(options = nil)
         adapter = WithAdvisoryLock::DatabaseAdapterSupport.new(connection)
         if adapter.postgresql?
           WithAdvisoryLock::PostgreSQL
         elsif adapter.mysql?
-          nested_lock = if [true, false].include?(options[:force_nested_lock_support])
-                          options[:force_nested_lock_support]
+          nested_lock = if options.respond_to?(:fetch) && [true, false].include?(options.fetch(:force_nested_lock_support))
+                          options.fetch(:force_nested_lock_support)
                         else
                           adapter.mysql_nested_lock_support?
                         end

--- a/lib/with_advisory_lock/concern.rb
+++ b/lib/with_advisory_lock/concern.rb
@@ -12,9 +12,8 @@ module WithAdvisoryLock
       end
 
       def with_advisory_lock_result(lock_name, options = {}, &block)
-        class_options = options.slice(:force_nested_lock_support)
-        instance_options = options.except(:force_nested_lock_support)
-        impl = impl_class(class_options).new(connection, lock_name, instance_options)
+        class_options = options.extract!(:force_nested_lock_support) if options.respond_to?(:fetch)
+        impl = impl_class(class_options).new(connection, lock_name, options)
         impl.with_advisory_lock_if_needed(&block)
       end
 

--- a/lib/with_advisory_lock/database_adapter_support.rb
+++ b/lib/with_advisory_lock/database_adapter_support.rb
@@ -1,5 +1,9 @@
 module WithAdvisoryLock
   class DatabaseAdapterSupport
+    # Caches nested lock support by MySQL reported version
+    @@mysql_nl_cache       = {}
+    @@mysql_nl_cache_mutex = Mutex.new
+
     def initialize(connection)
       @connection = connection
       @sym_name   = connection.adapter_name.downcase.to_sym
@@ -15,28 +19,36 @@ module WithAdvisoryLock
     def mysql_nested_lock_support?
       return false unless mysql?
 
-      lock_1 = "\"nested-test-1-#{SecureRandom.hex}\""
-      lock_2 = "\"nested-test-2-#{SecureRandom.hex}\""
+      # We select the MySQL version this way and cache on it, as MySQL will report versions like "5.7.5", and MariaDB will
+      # report versions like "10.3.8-MariaDB", which allow us to cache on features without introducing problems.
+      version = @connection.select_value("SELECT version()")
 
-      get_1  = @connection.select_value("SELECT GET_LOCK(#{lock_1}, 0) AS t#{SecureRandom.hex}")
-      get_2  = @connection.select_value("SELECT GET_LOCK(#{lock_2}, 0) AS t#{SecureRandom.hex}")
+      @@mysql_nl_cache_mutex.synchronize do
+        return @@mysql_nl_cache[version] if @@mysql_nl_cache.keys.include?(version)
 
-      # Both locks should succeed in old and new MySQL versions with "1"
-      raise RuntimeError, "Unexpected nested lock acquire result #{get_1}, #{get_2}" unless [get_1, get_2] == [1, 1]
+        lock_1 = "\"nested-test-1-#{SecureRandom.hex}\""
+        lock_2 = "\"nested-test-2-#{SecureRandom.hex}\""
 
-      release_1 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_1}) AS t#{SecureRandom.hex}")
-      release_2 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_2}) AS t#{SecureRandom.hex}")
+        get_1  = @connection.select_value("SELECT GET_LOCK(#{lock_1}, 0) AS t#{SecureRandom.hex}")
+        get_2  = @connection.select_value("SELECT GET_LOCK(#{lock_2}, 0) AS t#{SecureRandom.hex}")
 
-      # In MySQL <  5.7.5 release_1 will return  nil (not currently locked) and release_2 will return 1 (successfully unlocked)
-      # In MySQL >= 5.7.5 release_1 and release_2 will return 1 (both successfully unlocked)
-      # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock for more
-      case [release_1, release_2]
-      when [1, 1]
-        true
-      when [nil, 1]
-        false
-      else
-        raise RuntimeError, "Unexpected nested lock release result #{release_1}, #{release_2}"
+        # Both locks should succeed in old and new MySQL versions with "1"
+        raise RuntimeError, "Unexpected nested lock acquire result #{get_1}, #{get_2}" unless [get_1, get_2] == [1, 1]
+
+        release_1 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_1}) AS t#{SecureRandom.hex}")
+        release_2 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_2}) AS t#{SecureRandom.hex}")
+
+        # In MySQL <  5.7.5 release_1 will return  nil (not currently locked) and release_2 will return 1 (successfully unlocked)
+        # In MySQL >= 5.7.5 release_1 and release_2 will return 1 (both successfully unlocked)
+        # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock for more
+        @@mysql_nl_cache[version] = case [release_1, release_2]
+                                    when [1, 1]
+                                      true
+                                    when [nil, 1]
+                                      false
+                                    else
+                                      raise RuntimeError, "Unexpected nested lock release result #{release_1}, #{release_2}"
+                                    end
       end
     end
 

--- a/lib/with_advisory_lock/database_adapter_support.rb
+++ b/lib/with_advisory_lock/database_adapter_support.rb
@@ -1,11 +1,43 @@
 module WithAdvisoryLock
   class DatabaseAdapterSupport
     def initialize(connection)
-      @sym_name = connection.adapter_name.downcase.to_sym
+      @connection = connection
+      @sym_name   = connection.adapter_name.downcase.to_sym
     end
 
     def mysql?
       %i[mysql mysql2].include? @sym_name
+    end
+
+    # Nested lock support for MySQL was introduced in 5.7.5
+    # Checking by version number is complicated by MySQL compatible DBs (like MariaDB) having their own versioning schemes
+    # Therefore, we check for nested lock support by simply trying a nested lock, then testing and caching the outcome
+    def mysql_nested_lock_support?
+      return false unless mysql?
+
+      lock_1 = "\"nested-test-1-#{SecureRandom.hex}\""
+      lock_2 = "\"nested-test-2-#{SecureRandom.hex}\""
+
+      get_1  = @connection.select_value("SELECT GET_LOCK(#{lock_1}, 0) AS t#{SecureRandom.hex}")
+      get_2  = @connection.select_value("SELECT GET_LOCK(#{lock_2}, 0) AS t#{SecureRandom.hex}")
+
+      # Both locks should succeed in old and new MySQL versions with "1"
+      raise RuntimeError, "Unexpected nested lock acquire result #{get_1}, #{get_2}" unless [get_1, get_2] == [1, 1]
+
+      release_1 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_1}) AS t#{SecureRandom.hex}")
+      release_2 = @connection.select_value("SELECT RELEASE_LOCK(#{lock_2}) AS t#{SecureRandom.hex}")
+
+      # In MySQL <  5.7.5 release_1 will return  nil (not currently locked) and release_2 will return 1 (successfully unlocked)
+      # In MySQL >= 5.7.5 release_1 and release_2 will return 1 (both successfully unlocked)
+      # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock for more
+      case [release_1, release_2]
+      when [1, 1]
+        true
+      when [nil, 1]
+        false
+      else
+        raise RuntimeError, "Unexpected nested lock release result #{release_1}, #{release_2}"
+      end
     end
 
     def postgresql?

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -1,13 +1,8 @@
 module WithAdvisoryLock
+  # MySQL > 5.7.5 supports nested locks
   class MySQL < Base
-    # See http://dev.mysql.com/doc/refman/5.0/en/miscellaneous-functions.html#function_get-lock
+    # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
     def try_lock
-      unless lock_stack.empty?
-        raise NestedAdvisoryLockError.new(
-          "MySQL doesn't support nested Advisory Locks",
-          lock_stack.dup
-        )
-      end
       raise ArgumentError, 'shared locks are not supported on MySQL' if shared
       if transaction
         raise ArgumentError, 'transaction level locks are not supported on MySQL'
@@ -22,11 +17,6 @@ module WithAdvisoryLock
     def execute_successful?(mysql_function)
       sql = "SELECT #{mysql_function} AS #{unique_column_name}"
       connection.select_value(sql).to_i > 0
-    end
-
-    # MySQL doesn't support nested locks:
-    def already_locked?
-      lock_stack.last == lock_stack_item
     end
 
     # MySQL wants a string as the lock key.

--- a/lib/with_advisory_lock/mysql_no_nesting.rb
+++ b/lib/with_advisory_lock/mysql_no_nesting.rb
@@ -1,0 +1,20 @@
+module WithAdvisoryLock
+  # For MySQL < 5.7.5 that does not support nested locks
+  class MySQLNoNesting < MySQL
+    # See http://dev.mysql.com/doc/refman/5.0/en/miscellaneous-functions.html#function_get-lock
+    def try_lock
+      unless lock_stack.empty?
+        raise NestedAdvisoryLockError.new(
+          "MySQL doesn't support nested Advisory Locks",
+          lock_stack.dup
+        )
+      end
+      super
+    end
+
+    # MySQL doesn't support nested locks:
+    def already_locked?
+      lock_stack.last == lock_stack_item
+    end
+  end
+end

--- a/lib/with_advisory_lock/mysql_no_nesting.rb
+++ b/lib/with_advisory_lock/mysql_no_nesting.rb
@@ -5,7 +5,7 @@ module WithAdvisoryLock
     def try_lock
       unless lock_stack.empty?
         raise NestedAdvisoryLockError.new(
-          "MySQL doesn't support nested Advisory Locks",
+          "MySQL < 5.7.5 doesn't support nested Advisory Locks",
           lock_stack.dup
         )
       end

--- a/test/nesting_test.rb
+++ b/test/nesting_test.rb
@@ -25,8 +25,8 @@ describe "lock nesting" do
     impl.lock_stack.must_be_empty
   end
 
-  it "raises errors with MySQL when acquiring nested lock" do
-    skip unless env_db == :mysql
+  it "raises errors with MySQL < 5.7.5 when acquiring nested lock" do
+    skip unless env_db == :mysql && ENV['MYSQL_VERSION'] != '5.7'
     exc = proc {
       Tag.with_advisory_lock("first") do
         Tag.with_advisory_lock("second") do
@@ -36,8 +36,8 @@ describe "lock nesting" do
     exc.lock_stack.map(&:name).must_equal %w(first)
   end
 
-  it "supports nested advisory locks with !MySQL" do
-    skip if env_db == :mysql
+  it "supports nested advisory locks with !MySQL 5.6" do
+    skip if env_db == :mysql && ENV['MYSQL_VERSION'] != '5.7'
     impl = WithAdvisoryLock::Base.new(nil, nil, nil)
     impl.lock_stack.must_be_empty
     Tag.with_advisory_lock("first") do


### PR DESCRIPTION
This PR introduces support for nested locks in MySQL, which were introduced in MySQL 5.7.5.
More info in PR code comments.

Fixes #29.