### PR TITLE
Handle numeric lock names

### DIFF
--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -21,7 +21,11 @@ module WithAdvisoryLock
     end
 
     def execute_successful?(pg_function)
-      comment = lock_name.gsub(/(\/\*)|(\*\/)/, '--')
+      if lock_name.is_a? Numeric
+        comment = "Lock number: ##{lock_name}"
+      else
+        comment = lock_name.gsub(/(\/\*)|(\*\/)/, '--')
+      end
       sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name} /* #{comment} */"
       result = connection.select_value(sql)
       # MRI returns 't', jruby returns true. YAY!


### PR DESCRIPTION
`WithAdvisoryLock::Base` looks like it's set up to be able to handle a Numeric `lock_name`, however the code in `WithAdvisoryLock:PostgreSQL#execute_successful?` does not allow this as it uses `String#gsub` on the `lock_name` given for preparing an sql comment. This is a quick spike I'm using to fix this issue.