### PR TITLE
Add a `disable_query_cache` option to `with_advisory_lock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ If you want to see if the current Thread is holding a lock, you can call
 `Tag.current_advisory_lock` which will return the name of the current lock. If
 no lock is currently held, `.current_advisory_lock` returns `nil`.
 
+### ActiveRecord Query Cache
+
+You can optionally pass `disable_query_cache: true` to the options hash of
+`with_advisory_lock` in order to disable ActiveRecord's query cache. This can
+prevent problems when you query the database from within the lock and it returns
+stale results. More info on why this can be a problem can be
+[found here](https://github.com/ClosureTree/with_advisory_lock/issues/52)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/test/concern_test.rb
+++ b/test/concern_test.rb
@@ -19,3 +19,17 @@ describe 'with_advisory_lock.concern' do
     assert_respond_to(Label.new, :advisory_lock_exists?)
   end
 end
+
+describe 'ActiveRecord query cache' do
+  it 'does not disable quary cache by default' do
+    ActiveRecord::Base.expects(:uncached).never
+
+    Tag.with_advisory_lock('lock') { Tag.first }
+  end
+
+  it 'can disable ActiveRecord query cache' do
+    ActiveRecord::Base.expects(:uncached).once
+
+    Tag.with_advisory_lock('a-lock', disable_query_cache: true) { Tag.first }
+  end
+end


### PR DESCRIPTION
As per the discussion here https://github.com/ClosureTree/with_advisory_lock/issues/52 I have added the `disable_query_cache` option to the base class and updated the README.