### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 - Add `with_advisory_lock!`, which raises an error if the lock acquisition fails
+- Add a `disable_query_cache` option to `with_advisory_lock`
 
 ### 5.0.0
 - Drop support for EOL rubies and activerecord (ruby below 2.7 and activerecord below 6.0).


### PR DESCRIPTION
Add an entry to the CHANGELOG with the new `disable_query_cache` option. Not sure if this should go under the 5.0.0 header. Maybe it can be moved when v5 is released.