### PR TITLE
Don't fail lock release if the connection was disconnected

### DIFF
--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -14,6 +14,8 @@ module WithAdvisoryLock
       pg_function = "pg_advisory_unlock#{shared ? '_shared' : ''}"
       execute_successful?(pg_function)
     rescue ActiveRecord::StatementInvalid => e
+      # If something goes real bad, pg will close the connection. in that case the lock is no longer held
+      return if e.message =~ /PG::ConnectionBad:/
       raise unless e.message =~ / ERROR: +current transaction is aborted,/
 
       begin

--- a/test/lock_test.rb
+++ b/test/lock_test.rb
@@ -56,6 +56,12 @@ describe 'class methods' do
 
       thread_with_lock.kill
     end
+
+    it 'handles lost connection gracefully' do
+      Tag.with_advisory_lock(lock_name) { Tag.connection.disconnect! }
+
+      assert_nil(Tag.current_advisory_lock)
+    end
   end
 
   describe '.with_advisory_lock!' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,7 @@ puts "Testing with #{env_db} database, ActiveRecord #{ActiveRecord.gem_version} 
 module MiniTest
   class Spec
     before do
+      ActiveRecord::Base.establish_connection
       ENV['FLOCK_DIR'] = Dir.mktmpdir
       Tag.delete_all
       TagAudit.delete_all


### PR DESCRIPTION
If the connection is broken, then the lock was released because the session is aborted. Thus there is no need to fail.