### PR TITLE
raise exception if not in transaction

### DIFF
--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -5,6 +5,9 @@ module WithAdvisoryLock
     # See http://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
     def try_lock
       pg_function = "pg_try_advisory#{transaction ? '_xact' : ''}_lock#{shared ? '_shared' : ''}"
+      
+      raise "#{pg_function} requires transaction" if transaction && !ActiveRecord::Base.connection.transaction_open?
+      
       execute_successful?(pg_function)
     end
 

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -69,5 +69,15 @@ describe 'transaction scoping' do
       end
       assert_equal(0, pg_lock_count)
     end
+
+    specify 'transaction level locks fail if not in transaction' do
+      exception = assert_raises do
+        Tag.with_advisory_lock 'test', transaction: true do
+          raise 'should not get here'
+        end
+      end
+
+      assert_match(/#{Regexp.escape('requires transaction')}/, exception.message)
+    end
   end
 end


### PR DESCRIPTION
Should we raise exception to avoid incorrect usage of `transaction: true`? Another approach will be create transaction

Current behavior of library: it silently runs `SELECT pg_advisory_xact_lock(...)` that without transaction means lock with immediate unlock and then pass execution to block without active advisory lock. 