### PR TITLE
Use built-in wait and timeout functionality if the database engine supports it

### DIFF
--- a/lib/with_advisory_lock/flock.rb
+++ b/lib/with_advisory_lock/flock.rb
@@ -26,6 +26,10 @@ module WithAdvisoryLock
       0 == file_io.flock((shared ? File::LOCK_SH : File::LOCK_EX) | File::LOCK_NB)
     end
 
+    def lock
+      lock_via_sleep_loop
+    end
+
     def release_lock
       0 == file_io.flock(File::LOCK_UN)
     end

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -2,12 +2,20 @@
 
 module WithAdvisoryLock
   class MySQL < Base
-    # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
+    # See https://dev.mysql.com/doc/refman/en/locking-functions.html
     def try_lock
       raise ArgumentError, 'shared locks are not supported on MySQL' if shared
       raise ArgumentError, 'transaction level locks are not supported on MySQL' if transaction
 
       execute_successful?("GET_LOCK(#{quoted_lock_str}, 0)")
+    end
+
+    # See https://dev.mysql.com/doc/refman/en/locking-functions.html
+    def lock
+      raise ArgumentError, 'shared locks are not supported on MySQL' if shared
+      raise ArgumentError, 'transaction level locks are not supported on MySQL' if transaction
+
+      execute_successful?("GET_LOCK(#{quoted_lock_str}, #{timeout.nil? ? -1 : timeout})")
     end
 
     def release_lock

--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -8,6 +8,16 @@ module WithAdvisoryLock
       execute_successful?(pg_function)
     end
 
+    # See http://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
+    def lock
+      if timeout.nil?
+        pg_function = "pg_advisory#{transaction ? '_xact' : ''}_lock#{shared ? '_shared' : ''}"
+        execute_successful?(pg_function)
+      else
+        lock_via_sleep_loop
+      end
+    end
+
     def release_lock
       return if transaction
 

--- a/test/concern_test.rb
+++ b/test/concern_test.rb
@@ -21,7 +21,7 @@ class WithAdvisoryLockConcernTest < GemTestCase
 end
 
 class ActiveRecordQueryCacheTest < GemTestCase
-  test 'does not disable quary cache by default' do
+  test 'does not disable query cache by default' do
     ActiveRecord::Base.expects(:uncached).never
     Tag.with_advisory_lock('lock') { Tag.first }
   end

--- a/test/thread_test.rb
+++ b/test/thread_test.rb
@@ -7,13 +7,14 @@ class SeparateThreadTest < GemTestCase
     @lock_name = 'testing 1,2,3' # OMG COMMAS
     @mutex = Mutex.new
     @t1_acquired_lock = false
+    @t1_locking = true
     @t1_return_value = nil
 
     @t1 = Thread.new do
       ActiveRecord::Base.connection_pool.with_connection do
         @t1_return_value = Label.with_advisory_lock(@lock_name) do
           @mutex.synchronize { @t1_acquired_lock = true }
-          sleep
+          sleep(0.1) while @t1_locking
           't1 finished'
         end
       end
@@ -25,14 +26,46 @@ class SeparateThreadTest < GemTestCase
   end
 
   teardown do
+    @t1_locking = false
     @t1.wakeup if @t1.status == 'sleep'
     @t1.join
   end
 
-  test '#with_advisory_lock with a 0 timeout returns false immediately' do
+  test '#with_advisory_lock with no timeout waits until lock can be acquired, yields to the provided block, and then returns true' do
+    yielded_to = false
+    t2 = Thread.new { sleep(1); @t1_locking = false }
+    start_time = Time.now
+
+    response = Label.with_advisory_lock(@lock_name) do
+      yielded_to = true
+    end
+
+    t2.join
+
+    assert_in_delta(Time.now - start_time, 1, 0.5, "Expected with_advisory_lock to wait 1 second")
+    assert(yielded_to, "Expected with_advisory_lock to yield to the block")
+    assert(response, "Expect with_advisory_lock to return true")
+  end
+
+  test '#with_advisory_lock with a 0 timeout returns false immediately and does not yield to the provided block' do
+    start_time = Time.now
+
     response = Label.with_advisory_lock(@lock_name, 0) do
       raise 'should not be yielded to'
     end
+
+    assert_in_delta(Time.now - start_time, 0, 0.5, "Expected with_advisory_lock to return immediately")
+    assert_not(response)
+  end
+
+  test '#with_advisory_lock with a 1 timeout waits 1 second, returns false, and does not yield to the provided block' do
+    start_time = Time.now
+
+    response = Label.with_advisory_lock(@lock_name, 1) do
+      raise 'should not be yielded to'
+    end
+
+    assert_in_delta(Time.now - start_time, 1, 0.5, "Expected with_advisory_lock to wait 1 second")
     assert_not(response)
   end
 
@@ -45,6 +78,7 @@ class SeparateThreadTest < GemTestCase
   end
 
   test 'can re-establish the lock after the other thread releases it' do
+    @t1_locking = false
     @t1.wakeup
     @t1.join
     assert_equal('t1 finished', @t1_return_value)


### PR DESCRIPTION
This is regarding issue #80

- Added support for built-in wait and timeout functionality if the database engine supports it.
  - Unfortunately, PostgreSQL doesn't provide a function to wait for a lock with a specific timeout easily. For now, it will still use the existing Ruby-based sleep loop implementation if a timeout is specified.
  [There are ways to accomplish this with a function, but that has it's own drawbacks in terms of SQL query load](https://stackoverflow.com/questions/41230942/how-to-avoid-dead-lock-while-using-advisory-locks-in-postgresql)
- Added more test coverage regarding waiting for locks and transaction support with and without timeout.