### PR TITLE
chore: Add separate GitHub Actions for PostgreSQL and MySQL CI

### DIFF
--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -29,14 +29,14 @@ jobs:
           - 'truffleruby'
         rails:
           - 7.1
-          - 7.0
+          - "7.0"
           - 6.1
         adapter:
-          - mysql2://with_advisory:with_advisory_lock_test@0/with_advisory_lock_test
-          - trilogy://with_advisory:with_advisory_lock_test@0/with_advisory_lock_test
+          - mysql2://with_advisory:with_advisory_pass@0/with_advisory_lock_test
+          - trilogy://with_advisory:with_advisory_pass@0/with_advisory_lock_test
         include:
           - ruby: jruby
-            rails: activerecord_6.1
+            rails: 6.1
             adapter: jdbcmysql://with_advisory:with_advisory_pass@0/with_advisory_lock_test
     steps:
       - name: Checkout

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -1,19 +1,27 @@
----
-name: CI
-
+name: CI Mysql
 on:
   pull_request:
     branches:
       - master
-
 jobs:
   minitest:
     runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
+    services:
+      mysql:
+        image: mysql/mysql-server:5.7
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_USER: with_advisory
+          MYSQL_PASSWORD: with_advisory_pass
+          MYSQL_DATABASE: with_advisory_lock_test
+          MYSQL_ROOT_HOST: '%'
     strategy:
       fail-fast: false
       matrix:
         ruby:
-          - '3.2'  
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -24,15 +32,15 @@ jobs:
           - 7.0
           - 6.1
         adapter:
-          - sqlite3:///tmp/test.sqlite3
+          - mysql2://with_advisory:with_advisory_lock_test@0/with_advisory_lock_test
+          - trilogy://with_advisory:with_advisory_lock_test@0/with_advisory_lock_test
         include:
           - ruby: jruby
             rails: activerecord_6.1
-            adapter: jdbcsqlite3:///tmp/test.sqlite3
+            adapter: jdbcmysql://with_advisory:with_advisory_pass@0/with_advisory_lock_test
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -40,8 +48,7 @@ jobs:
           bundler-cache: true
           rubygems: latest
         env:
-          BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.rails }}.gemfile
-
+          BUNDLE_GEMFILE:  gemfiles/activerecord_${{ matrix.rails }}.gemfile
       - name: Test
         env:
           BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.rails }}.gemfile

--- a/.github/workflows/ci-postgresql.yml
+++ b/.github/workflows/ci-postgresql.yml
@@ -1,19 +1,29 @@
----
-name: CI
-
+name: CI Postgresql
 on:
   pull_request:
     branches:
       - master
-
 jobs:
   minitest:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: 'postgres:14-alpine'
+        ports: ['5432:5432']
+        env:
+          POSTGRES_USER: with_advisory
+          POSTGRES_PASSWORD: with_advisory_pass
+          POSTGRES_DB: with_advisory_lock_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
         ruby:
-          - '3.2'  
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'
@@ -24,15 +34,14 @@ jobs:
           - 7.0
           - 6.1
         adapter:
-          - sqlite3:///tmp/test.sqlite3
+          - postgres://with_advisory:with_advisory_pass@0/with_advisory_lock_test
         include:
           - ruby: jruby
             rails: activerecord_6.1
-            adapter: jdbcsqlite3:///tmp/test.sqlite3
+            adapter: jdbcpostgresql://with_advisory:with_advisory_pass@0/with_advisory_lock_test
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -40,11 +49,10 @@ jobs:
           bundler-cache: true
           rubygems: latest
         env:
-          BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.rails }}.gemfile
-
+          BUNDLE_GEMFILE:  gemfiles/activerecord_${{ matrix.rails }}.gemfile
       - name: Test
         env:
-          BUNDLE_GEMFILE: gemfiles/activerecord_${{ matrix.rails }}.gemfile
+          BUNDLE_GEMFILE:  gemfiles/activerecord_${{ matrix.rails }}.gemfile
           DATABASE_URL: ${{ matrix.adapter }}
           WITH_ADVISORY_LOCK_PREFIX: ${{ github.run_id }}
         run: bundle exec rake

--- a/.github/workflows/ci-postgresql.yml
+++ b/.github/workflows/ci-postgresql.yml
@@ -31,13 +31,13 @@ jobs:
           - 'truffleruby'
         rails:
           - 7.1
-          - 7.0
+          - "7.0"
           - 6.1
         adapter:
           - postgres://with_advisory:with_advisory_pass@0/with_advisory_lock_test
         include:
           - ruby: jruby
-            rails: activerecord_6.1
+            rails: 6.1
             adapter: jdbcpostgresql://with_advisory:with_advisory_pass@0/with_advisory_lock_test
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
           - 'truffleruby'
         rails:
           - 7.1
-          - 7.0
+          - "7.0"
           - 6.1
         adapter:
           - sqlite3:///tmp/test.sqlite3
         include:
           - ruby: jruby
-            rails: activerecord_6.1
+            rails: 6.1
             adapter: jdbcsqlite3:///tmp/test.sqlite3
     steps:
       - name: Checkout


### PR DESCRIPTION
Separated PostgreSQL and MySQL configurations into distinct GitHub Actions for clarity and easier maintenance. 

Updated .github/workflows/ci.yml to remove redundancies while creating ci-postgresql.yml and ci-mysql.yml with respective configurations. 

This enhances our CI/CD pipeline by organizing workflows better and ensuring clear separation between SQL variants.