### PR TITLE
chore: Refactor and optimize MySQL advisory lock handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: test-pg test-mysql
+
+test-pg:
+	docker compose up -d pg
+	sleep 10 # give some time for the service to start
+	DATABASE_URL=postgres://with_advisory:with_advisory_pass@localhost/with_advisory_lock_test appraisal rake test
+
+test-mysql:
+	docker compose up -d mysql
+	sleep 10 # give some time for the service to start
+	DATABASE_URL=mysql2://with_advisory:with_advisory_pass@0.0.0.0:3306/with_advisory_lock_test appraisal rake test
+
+
+test: test-pg test-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+  pg:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: with_advisory
+      POSTGRES_PASSWORD: with_advisory_pass
+      POSTGRES_DB: with_advisory_lock_test
+    ports:
+      - "5432:5432"
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_USER: with_advisory
+      MYSQL_PASSWORD: with_advisory_pass
+      MYSQL_DATABASE: with_advisory_lock_test
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_ROOT_HOST: '%'
+    ports:
+      - "3306:3306"

--- a/lib/with_advisory_lock/mysql.rb
+++ b/lib/with_advisory_lock/mysql.rb
@@ -2,10 +2,8 @@
 
 module WithAdvisoryLock
   class MySQL < Base
-    # Caches nested lock support by MySQL reported version
-    @@mysql_nl_cache       = {}
-    @@mysql_nl_cache_mutex = Mutex.new
-    # See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
+    # See https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html
+    # See https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html
     def try_lock
       raise ArgumentError, 'shared locks are not supported on MySQL' if shared
       raise ArgumentError, 'transaction level locks are not supported on MySQL' if transaction
@@ -18,8 +16,12 @@ module WithAdvisoryLock
     end
 
     def execute_successful?(mysql_function)
-      sql = "SELECT #{mysql_function} AS #{unique_column_name}"
-      connection.select_value(sql).to_i.positive?
+      execute_query(mysql_function) == 1
+    end
+
+    def execute_query(mysql_function)
+      sql = "SELECT #{mysql_function}"
+      connection.query_value(sql)
     end
 
     # MySQL wants a string as the lock key.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,9 +49,11 @@ class GemTestCase < ActiveSupport::TestCase
 
   setup do
     ENV['FLOCK_DIR'] = Dir.mktmpdir if is_sqlite3_adapter?
-    Tag.delete_all
-    TagAudit.delete_all
-    Label.delete_all
+    ApplicationRecord.connection.truncate_tables(
+      Tag.table_name,
+      TagAudit.table_name,
+      Label.table_name
+    )
   end
 
   teardown do
@@ -60,3 +62,4 @@ class GemTestCase < ActiveSupport::TestCase
 end
 
 puts "Testing with #{env_db} database, ActiveRecord #{ActiveRecord.gem_version} and #{RUBY_ENGINE} #{RUBY_ENGINE_VERSION} as #{RUBY_VERSION}"
+puts "Connection Pool size: #{ActiveRecord::Base.connection_pool.size}"

--- a/test/with_advisory_lock/shared_test.rb
+++ b/test/with_advisory_lock/shared_test.rb
@@ -24,7 +24,7 @@ class SharedTestWorker
   private
 
   def work
-    ApplicationRecord.connection_pool.with_connection do
+    Tag.connection_pool.with_connection do
       Tag.with_advisory_lock('test', timeout_seconds: 0, shared: @shared) do
         @locked = true
         sleep 0.01 until @cleanup
@@ -117,7 +117,7 @@ class SupportedEnvironmentTest < SharedLocksTest
     end
 
     def pg_lock_modes
-      ApplicationRecord.connection.select_values("SELECT mode FROM pg_locks WHERE locktype = 'advisory';")
+      Tag.connection.select_values("SELECT mode FROM pg_locks WHERE locktype = 'advisory';")
     end
 
     test 'allows shared lock to be upgraded to an exclusive lock' do

--- a/test/with_advisory_lock/thread_test.rb
+++ b/test/with_advisory_lock/thread_test.rb
@@ -10,7 +10,7 @@ class SeparateThreadTest < GemTestCase
     @t1_return_value = nil
 
     @t1 = Thread.new do
-      ApplicationRecord.connection_pool.with_connection do
+      Label.connection_pool.with_connection do
         @t1_return_value = Label.with_advisory_lock(@lock_name) do
           @mutex.synchronize { @t1_acquired_lock = true }
           sleep
@@ -21,7 +21,7 @@ class SeparateThreadTest < GemTestCase
 
     # Wait for the thread to acquire the lock:
     sleep(0.1) until @mutex.synchronize { @t1_acquired_lock }
-    ApplicationRecord.connection.reconnect!
+    Label.connection.reconnect!
   end
 
   teardown do


### PR DESCRIPTION
This commit removes unused MySQL lock variables,