### PR TITLE
Set the pool to 20 in test_helper.rb.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ end
 ActiveRecord::Base.configurations = {
   default_env: {
     url: ENV.fetch('DATABASE_URL', "sqlite3://#{Dir.tmpdir}/with_advisory_lock_test#{RUBY_VERSION}-#{ActiveRecord.gem_version}.sqlite3"),
+    pool: 20,
     properties: { allowPublicKeyRetrieval: true } # for JRuby madness
   }
 }


### PR DESCRIPTION
I am the maintainer of the Debian with_advisory_lock package.

https://tracker.debian.org/pkg/ruby-with-advisory-lock

Currently, tests are failing during build because the environment spawns a pool of 5 but the tests run with 10 workers, leading some of the connections to fail.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1095888

The solution is this simple pull request.

https://lists.debian.org/debian-ruby/2025/03/msg00013.html

I have already applied this to the Debian package, but I assume that having it upstream will be helpful for other people.