### PR TITLE
Avoid query cache for lock queries

### DIFF
--- a/lib/with_advisory_lock/mysql_advisory.rb
+++ b/lib/with_advisory_lock/mysql_advisory.rb
@@ -65,7 +65,7 @@ module WithAdvisoryLock
     private
 
     def execute_successful?(mysql_function)
-      select_value("SELECT #{mysql_function}") == 1
+      query_value("SELECT #{mysql_function}") == 1
     end
   end
 end

--- a/lib/with_advisory_lock/postgresql_advisory.rb
+++ b/lib/with_advisory_lock/postgresql_advisory.rb
@@ -71,7 +71,7 @@ module WithAdvisoryLock
         LIMIT 1
       SQL
 
-      select_value(query).present?
+      query_value(query).present?
     rescue ActiveRecord::StatementInvalid
       # If pg_locks is not accessible, fall back to nil to indicate we should use the default method
       nil
@@ -96,7 +96,7 @@ module WithAdvisoryLock
     end
 
     def execute_advisory(function, lock_keys, lock_name)
-      result = select_value(prepare_sql(function, lock_keys, lock_name))
+      result = query_value(prepare_sql(function, lock_keys, lock_name))
       LOCK_RESULT_VALUES.include?(result)
     end
 

--- a/test/with_advisory_lock/mysql_release_lock_test.rb
+++ b/test/with_advisory_lock/mysql_release_lock_test.rb
@@ -69,7 +69,7 @@ class MySQLReleaseLockTest < GemTestCase
 
     # Acquire lock using SQL (ActiveRecord doesn't provide get_advisory_lock method)
     lock_keys = model_class.connection.lock_keys_for(lock_name)
-    result = model_class.connection.select_value("SELECT GET_LOCK(#{model_class.connection.quote(lock_keys.first)}, 0)")
+    result = model_class.connection.query_value("SELECT GET_LOCK(#{model_class.connection.quote(lock_keys.first)}, 0)")
     assert_equal 1, result, 'Failed to acquire lock using SQL'
 
     # Release using ActiveRecord signature (positional argument, as Rails does)
@@ -78,11 +78,11 @@ class MySQLReleaseLockTest < GemTestCase
 
     # Verify lock is released
     lock_keys = model_class.connection.lock_keys_for(lock_name)
-    result = model_class.connection.select_value("SELECT GET_LOCK(#{model_class.connection.quote(lock_keys.first)}, 0)")
+    result = model_class.connection.query_value("SELECT GET_LOCK(#{model_class.connection.quote(lock_keys.first)}, 0)")
     assert_equal 1, result, 'Lock was not properly released'
 
     # Clean up
-    model_class.connection.select_value("SELECT RELEASE_LOCK(#{model_class.connection.quote(lock_keys.first)})")
+    model_class.connection.query_value("SELECT RELEASE_LOCK(#{model_class.connection.quote(lock_keys.first)})")
   end
 
   test 'release_advisory_lock handles connection errors gracefully' do
@@ -116,4 +116,3 @@ class MySQLReleaseLockTest < GemTestCase
     end
   end
 end
-

--- a/test/with_advisory_lock/transaction_test.rb
+++ b/test/with_advisory_lock/transaction_test.rb
@@ -7,8 +7,8 @@ class PostgreSQLTransactionScopingTest < GemTestCase
 
   setup do
     @pg_lock_count = lambda do
-      backend_pid = Tag.connection.select_value('SELECT pg_backend_pid()')
-      Tag.connection.select_value("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND pid = #{backend_pid};").to_i
+      backend_pid = Tag.connection.query_value('SELECT pg_backend_pid()')
+      Tag.connection.query_value("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND pid = #{backend_pid};").to_i
     end
   end
 


### PR DESCRIPTION
Hello hello, in the mega commit 935e7e5f `connection.query_value(...)` was replaced with `connection.select_value(...)` in the connection extension modules that issue the lock queries (on mysql in my case). The older function bypasses the query cache but the latter does not.

Builtin rails query logger should show the queries in both cases, and the cached query in the second case:

```rb
connection = ActiveRecord::Base.connection
connection.cache do
  connection.query_value("SELECT GET_LOCK('hello', 1)")
  connection.query_value("SELECT RELEASE_LOCK('hello')")
  connection.query_value("SELECT GET_LOCK('hello', 1)")
end
connection.cache do
  connection.select_value("SELECT GET_LOCK('hello', 1)")
  connection.select_value("SELECT RELEASE_LOCK('hello')")
  connection.select_value("SELECT GET_LOCK('hello', 1)") # <= cached
end
```

May result in unreleased locks with patterns like this:

```
GET_LOCK
  10000 app queries
RELEASE_LOCK
GET_LOCK
  10 app queries
CACHED RELEASE_LOCK
```

Added a single test after changing every `select_value` to `query_value` rather indiscriminately 😅 