### PR TITLE
Add test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ concurrent access to **any instance of a model**. Their coarseness means they
 aren't going to be commonly applicable, and they can be a source of
 [deadlocks](http://en.wikipedia.org/wiki/Deadlock).
 
+## Running Tests
+
+To setup the project and run the whole test suite:
+
+1. Have Docker running
+2. `echo -e "DATABASE_URL_PG=postgres://with_advisory:with_advisory_pass@localhost:5433/with_advisory_lock_test\nDATABASE_URL_MYSQL=mysql2://with_advisory:with_advisory_pass@127.0.0.1:3366/with_advisory_lock_test" > .env`
+3. `make`
+
+Alternatively to `make`, run `bin/rails test` to skip database and dependency setup.
+
 ## FAQ
 
 ### Transactions and Advisory Locks

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ aren't going to be commonly applicable, and they can be a source of
 To setup the project and run the whole test suite:
 
 1. Have Docker running
-2. `echo -e "DATABASE_URL_PG=postgres://with_advisory:with_advisory_pass@localhost:5433/with_advisory_lock_test\nDATABASE_URL_MYSQL=mysql2://with_advisory:with_advisory_pass@127.0.0.1:3366/with_advisory_lock_test" > .env`
+2. `echo -e "DB_USER=with_advisory\nDB_PASSWORD=with_advisory_pass\nDB_NAME=with_advisory_lock_test\nDATABASE_URL_PG=postgres://\$DB_USER:\$DB_PASSWORD@localhost:5433/\$DB_NAME\nDATABASE_URL_MYSQL=mysql2://\$DB_USER:\$DB_PASSWORD@127.0.0.1:3366/\$DB_NAME" > .env`
 3. `make`
 
 Alternatively to `make`, run `bin/rails test` to skip database and dependency setup.

--- a/bin/setup_test_db
+++ b/bin/setup_test_db
@@ -3,6 +3,8 @@
 
 require 'bundler/setup'
 require 'active_record'
+require 'dotenv'
+Dotenv.load
 
 # Setup PostgreSQL database
 puts 'Setting up PostgreSQL test database...'
@@ -10,9 +12,9 @@ ActiveRecord::Base.establish_connection(
   adapter: 'postgresql',
   host: 'localhost',
   port: 5433,
-  database: 'with_advisory_lock_test',
-  username: 'with_advisory',
-  password: 'with_advisory_pass'
+  database: ENV['DB_NAME'],
+  username: ENV['DB_USER'],
+  password: ENV['DB_PASSWORD']
 )
 
 ActiveRecord::Schema.define(version: 1) do
@@ -36,9 +38,9 @@ ActiveRecord::Base.establish_connection(
   adapter: 'mysql2',
   host: '127.0.0.1',
   port: 3366,
-  database: 'with_advisory_lock_test',
-  username: 'with_advisory',
-  password: 'with_advisory_pass'
+  database: ENV['DB_NAME'],
+  username: ENV['DB_USER'],
+  password: ENV['DB_PASSWORD']
 )
 
 ActiveRecord::Schema.define(version: 1) do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ services:
   pg:
     image: postgres:17-alpine
     environment:
-      POSTGRES_USER: with_advisory
-      POSTGRES_PASSWORD: with_advisory_pass
-      POSTGRES_DB: with_advisory_lock_test
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     ports:
       - "5433:5432"
   mysql:
     image: mysql:8
     environment:
-      MYSQL_USER: with_advisory
-      MYSQL_PASSWORD: with_advisory_pass
-      MYSQL_DATABASE: with_advisory_lock_test
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
       MYSQL_ROOT_HOST: '%'
     ports:


### PR DESCRIPTION
Following https://github.com/ClosureTree/with_advisory_lock/pull/131#issuecomment-3239420265, where the PR's author didn't know how to test his changes.

Added reads of the ENV vars in places as I didn't want to add more hardcoded DB configurations. There are more files like `bin/test_connections` that could read the ENV vars but I don't want to assume the dev workflow for this gem, so I focused on the typical test path.

I thought of tracking the `.env` file but I figure people may want to connect to other databases.